### PR TITLE
Changed deprecated URL

### DIFF
--- a/src/clj_github_app/token_manager.clj
+++ b/src/clj_github_app/token_manager.clj
@@ -94,7 +94,7 @@
       (fn []
         (make-app-token signing-algorithm github-app-id))
       (fn [installation-id]
-        (let [url (uri/resolve-uri (str github-api-url "/") (str "installations/" (codec/url-encode (str installation-id)) "/access_tokens"))]
+        (let [url (uri/resolve-uri (str github-api-url "/") (str "app/installations/" (codec/url-encode (str installation-id)) "/access_tokens"))]
           (:body (http/post url
                             {:oauth-token (make-app-token signing-algorithm github-app-id)
                              :as          :json

--- a/test/clj_github_app/token_manager_test.clj
+++ b/test/clj_github_app/token_manager_test.clj
@@ -21,7 +21,7 @@
   (testing "Installation token is retrieved correctly"
     (with-redefs [tm/make-app-token (fn [_ _] "app-token")
                   http/post         (fn [url opts]
-                                      (is (= url "https://github-api.example.com/installations/1/access_tokens"))
+                                      (is (= url "https://github-api.example.com/app/installations/1/access_tokens"))
                                       (is (= (:oauth-token opts) "app-token"))
                                       access-token-response)]
       (let [tm (make-test-token-manager)]


### PR DESCRIPTION
Github is deprecating the '/installations' endpoint in favor of '/app/installations'. This PR aims to prepare the library for this change.