### PR TITLE
Add `check-payload-signature-256`, deprecate `check-payload-signature`

### DIFF
--- a/src/clj_github_app/webhook_signature.clj
+++ b/src/clj_github_app/webhook_signature.clj
@@ -1,9 +1,10 @@
 (ns clj-github-app.webhook-signature
   (:require [clojure.string :as str]
             [crypto.equality]
-            [pandect.algo.sha1 :as sha1]))
+            [pandect.algo.sha1 :as sha1]
+            [pandect.algo.sha256 :as sha256]))
 
-(defn check-payload-signature [webhook-secret x-hub-signature payload]
+(defn ^{:deprecated "Prefer using check-payload-signature-256."} check-payload-signature [webhook-secret x-hub-signature payload]
   (if (str/blank? webhook-secret)
     ::not-checked
     (if (str/blank? x-hub-signature)
@@ -13,4 +14,12 @@
           ::wrong-signature
           ::ok)))))
 
-
+(defn check-payload-signature-256 [webhook-secret x-hub-signature-256 payload]
+  (if (str/blank? webhook-secret)
+    ::not-checked
+    (if (str/blank? x-hub-signature-256)
+      ::missing-signature
+      (let [payload-signature (str "sha256=" (sha256/sha256-hmac payload webhook-secret))]
+        (if-not (crypto.equality/eq? payload-signature x-hub-signature-256)
+          ::wrong-signature
+          ::ok)))))

--- a/test/clj_github_app/webhook_signature_test.clj
+++ b/test/clj_github_app/webhook_signature_test.clj
@@ -1,7 +1,8 @@
 (ns clj-github-app.webhook-signature-test
   (:require [clj-github-app.webhook-signature :refer :all :as ws]
             [clojure.test :refer :all]
-            [pandect.algo.sha1 :as sha1]))
+            [pandect.algo.sha1 :as sha1]
+            [pandect.algo.sha256 :as sha256]))
 
 (deftest works
   (testing "When webhook secret is blank, returns :clj-github-app.webhook-signature/not-checked"
@@ -21,5 +22,25 @@
   (testing ""
     (are [?payload ?res]
          (= ?res (check-payload-signature "secret" (str "sha1=" (sha1/sha1-hmac "signed-payload" "secret")) ?payload))
+      "signed-payload" :clj-github-app.webhook-signature/ok
+      "tampered-payload" :clj-github-app.webhook-signature/wrong-signature))
+
+  (testing "When webhook secret is blank, returns :clj-github-app.webhook-signature/not-checked"
+    (are [?in]
+         (= ::ws/not-checked (check-payload-signature-256 ?in nil nil))
+      nil
+      ""
+      " "))
+
+  (testing "When X-Hub-Signature-256 is blank or missing, returns :clj-github-app.webhook-signature/missing-signature"
+    (are [?in]
+         (= ::ws/missing-signature (check-payload-signature-256 "secret" ?in nil))
+      nil
+      ""
+      " "))
+
+  (testing ""
+    (are [?payload ?res]
+         (= ?res (check-payload-signature-256 "secret" (str "sha256=" (sha256/sha256-hmac "signed-payload" "secret")) ?payload))
       "signed-payload" :clj-github-app.webhook-signature/ok
       "tampered-payload" :clj-github-app.webhook-signature/wrong-signature)))


### PR DESCRIPTION
(GitHub already recommends one [to use `X-Hub-Signature-256` rather than `X-Hub-Signature`](https://docs.github.com/en/developers/webhooks-and-events/webhooks/securing-your-webhooks#validating-payloads-from-github) for improved security)